### PR TITLE
Add migration examples and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,43 @@ skemabase parse schema.sb --output schema.json
 skemabase generate sql schema.sb --dialect postgresql --output schema.sql
 ```
 Supports relationships (belongs_to, has_many, has_one, habtm) and constraints.
+
+### Migrations
+Use reversible migrations to evolve your schema.
+
+Initialize migrations folder, create empty or diff migrations, and preview or rollback migrations:
+```bash
+# Initialize migrations folder
+skemabase migrate init
+
+# Create an empty migration
+skemabase migrate create add_users_table
+
+# Create a diff migration between IR snapshots (or schema files)
+skemabase migrate create add_email --from schema_v1.json --to schema_v2.json
+# or directly from schema files:
+skemabase migrate create add_email --from schema_v1.sb --to schema_v2.sb
+
+# Preview the next migration SQL (dry run)
+skemabase migrate up --dry-run
+
+# Roll back the last two migrations (dry run)
+skemabase migrate down 2 --dry-run
+```
+
+Options:
+- `--from`     Path to old IR JSON file or schema file (for create)
+- `--to`       Path to new IR JSON file or schema file (for create)
+- `--dry-run`  Print SQL without executing
+- `--dialect`, `-d`  SQL dialect (`postgresql`|`sqlite`)
+
+Supports relationships (`belongs_to`, `has_many`, `has_one`, `habtm`) and constraints.
+
+Note: At this time, `migrate up` and `migrate down` only generate SQL and do not execute against a live database.
 ### Version
 ```bash
 $ skemabase --version
-0.1.0
+0.1.1
 ```
 Supports relationships defined in the schema (has_many, has_one, belongs_to, has and belongs to many).
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,6 +12,9 @@ function usage() {
     'Usage:' +
     '\n  skemabase parse <input.sb> --output <output.json>' +
     '\n  skemabase generate sql <input.sb> --dialect <dialect> --output <output.sql>' +
+    '\n  skemabase migrate init' +
+    '\n  skemabase migrate create <name> [--from <oldIR.json> --to <newIR.json>]' +
+    '\n  skemabase migrate up|down [<n>] [--dry-run] [--dialect <dialect>]' +
     '\n\nOptions:' +
     '\n  --help, -h      Show help message' +
     '\n  --version, -v   Show version' +
@@ -111,6 +114,100 @@ if (cmd === 'parse') {
   } else {
     console.log(sql);
   }
+} else if (cmd === 'migrate') {
+  const sub = args[1];
+  if (!sub) printError('Error: Missing migrate subcommand (init, create, up, down).');
+  // migrate init
+  if (sub === 'init') {
+    const migrationsDir = path.join(process.cwd(), 'migrations');
+    if (fs.existsSync(migrationsDir)) {
+      console.log('Migrations directory already exists at ./migrations');
+    } else {
+      fs.mkdirSync(migrationsDir);
+      console.log('Created migrations directory at ./migrations');
+    }
+    process.exit(0);
+  }
+  // migrate create
+  if (sub === 'create') {
+    const name = args[2];
+    if (!name) printError('Error: Missing migration name for create.');
+    const fromIdx = args.indexOf('--from');
+    const toIdx = args.indexOf('--to');
+    const { diffSchemas } = require(path.join(__dirname, '..', 'skemabase-js', 'src', 'migration'));
+    let migration;
+    // Load IR from files: support .sb (schema) or .json (IR)
+    let oldIR = [];
+    let newIR = [];
+    try {
+      if (fromIdx !== -1) {
+        const fromPath = args[fromIdx + 1];
+        const data = fs.readFileSync(fromPath, 'utf-8');
+        if (path.extname(fromPath) === '.sb') {
+          oldIR = parse(data);
+        } else {
+          oldIR = JSON.parse(data);
+        }
+      }
+      if (toIdx !== -1) {
+        const toPath = args[toIdx + 1];
+        const data = fs.readFileSync(toPath, 'utf-8');
+        if (path.extname(toPath) === '.sb') {
+          newIR = parse(data);
+        } else {
+          newIR = JSON.parse(data);
+        }
+      }
+    } catch (err) {
+      printError(`Error reading IR files: ${err.message}`);
+    }
+    migration = diffSchemas(oldIR, newIR);
+    const timestamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+/, '');
+    const safe = name.replace(/\s+/g, '_').replace(/[^\w\-]/g, '').toLowerCase();
+    const filename = `${timestamp}_${safe}.js`;
+    const migrationsDir = path.join(process.cwd(), 'migrations');
+    if (!fs.existsSync(migrationsDir)) printError('Error: migrations directory not found. Run `skemabase migrate init` first.');
+    const filePath = path.join(migrationsDir, filename);
+    const content = `module.exports = ${JSON.stringify(migration, null, 2)};\n`;
+    fs.writeFileSync(filePath, content);
+    console.log(`Created migration: ${filePath}`);
+    process.exit(0);
+  }
+  // migrate up/down
+  if (sub === 'up' || sub === 'down') {
+    const migrationsDir = path.join(process.cwd(), 'migrations');
+    if (!fs.existsSync(migrationsDir)) printError('Error: migrations directory not found. Run `skemabase migrate init` first.');
+    let count = null;
+    const maybeN = args[2];
+    if (maybeN && !maybeN.startsWith('-')) {
+      const v = parseInt(maybeN, 10);
+      if (Number.isNaN(v)) printError(`Error: Invalid migration count: ${maybeN}`);
+      count = v;
+    }
+    const dryRun = args.includes('--dry-run');
+    let dialect = 'postgresql';
+    let dIdx = args.indexOf('--dialect');
+    if (dIdx === -1) dIdx = args.indexOf('-d');
+    if (dIdx !== -1) dialect = args[dIdx + 1];
+    let files = fs.readdirSync(migrationsDir).filter(f => f.endsWith('.js')).sort();
+    if (sub === 'down') files = files.reverse();
+    if (count != null) files = files.slice(0, count);
+    if (files.length === 0) {
+      console.log('No migrations to process.');
+      process.exit(0);
+    }
+    const { generateMigrationSQL } = require(path.join(__dirname, '..', 'skemabase-js', 'src', 'migration'));
+    for (const file of files) {
+      const migration = require(path.join(process.cwd(), 'migrations', file));
+      const { upSQL, downSQL } = generateMigrationSQL(migration, { dialect });
+      console.log(`-- Migration: ${file}`);
+      console.log(sub === 'up' ? upSQL : downSQL);
+      console.log();
+    }
+    if (!dryRun) console.log('Note: live execution not yet implemented.');
+    process.exit(0);
+  }
+  printError(`Error: Unrecognized migrate subcommand: ${sub}`);
 } else {
   printError(`Error: Unrecognized command: ${args.join(' ')}`);
 }

--- a/cli.test.js
+++ b/cli.test.js
@@ -94,4 +94,43 @@ describe('skemabase CLI', () => {
     expect(result.stdout.trim()).toBe(pkg.version);
     expect(result.stderr).toBe('');
   });
+  
+  describe('migrate commands', () => {
+    it('should create migrations directory on migrate init', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'skemabase-'));
+      const result = spawnSync(node, [cli, 'migrate', 'init'], { cwd: tmp, encoding: 'utf-8' });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/Created migrations directory at \.\/migrations/);
+      expect(fs.existsSync(path.join(tmp, 'migrations'))).toBe(true);
+      expect(result.stderr).toBe('');
+      const result2 = spawnSync(node, [cli, 'migrate', 'init'], { cwd: tmp, encoding: 'utf-8' });
+      expect(result2.status).toBe(0);
+      expect(result2.stdout).toMatch(/Migrations directory already exists at \.\/migrations/);
+      expect(result2.stderr).toBe('');
+    });
+
+    it('should error on migrate create without init', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'skemabase-'));
+      const result = spawnSync(node, [cli, 'migrate', 'create', 'test_mig'], { cwd: tmp, encoding: 'utf-8' });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/Error: migrations directory not found\. Run `skemabase migrate init` first\./);
+      expect(result.stdout).toMatch(/Usage:/);
+    });
+
+    it('should create a migration file on migrate create after init', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'skemabase-'));
+      spawnSync(node, [cli, 'migrate', 'init'], { cwd: tmp, encoding: 'utf-8' });
+      const result = spawnSync(node, [cli, 'migrate', 'create', 'add_test'], { cwd: tmp, encoding: 'utf-8' });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/Created migration: .*add_test\.js/);
+      expect(result.stderr).toBe('');
+      const migrationsDir = path.join(tmp, 'migrations');
+      const files = fs.readdirSync(migrationsDir).filter(f => f.endsWith('.js'));
+      expect(files.length).toBe(1);
+      const content = fs.readFileSync(path.join(migrationsDir, files[0]), 'utf-8');
+      expect(content).toMatch(/module\.exports =/);
+      expect(content).toMatch(/"up": \[\]/);
+      expect(content).toMatch(/"down": \[\]/);
+    });
+  });
 });

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -52,6 +52,59 @@ $ skemabase --version
  skemabase generate sql schema.sb --dialect sqlite --output schema.sql
  ```
 Supports relationships defined in the schema (has_many, has_one, belongs_to, has and belongs to many).
+### migrate
+
+Use reversible migrations (up/down) to evolve your schema.
+
+Usage:
+```bash
+skemabase migrate init
+skemabase migrate create <name> [--from <oldIR.json|schema.sb>] [--to <newIR.json|schema.sb>]
+skemabase migrate up|down [<n>] [--dry-run] [--dialect <dialect>]
+```
+
+Options:
+- `--from`   Path to old IR JSON file or schema file (for create)
+- `--to`     Path to new IR JSON file or schema file (for create)
+- `--dry-run`  Print SQL without executing
+- `--dialect`, `-d`  SQL dialect (`postgresql`|`sqlite`). Default: `postgresql`.
+
+Note: At this time, `migrate up` and `migrate down` only generate SQL and do not execute against a live database.
+
+Examples:
+```bash
+# Initialize migrations folder
+skemabase migrate init
+
+# Create an empty migration
+skemabase migrate create add_users_table
+
+# Create a diff migration between schema or IR snapshots
+skemabase migrate create add_email --from schema_v1.sb --to schema_v2.sb
+  # or: skemabase migrate create add_email --from schema_v1.json --to schema_v2.json
+
+# Preview the next migration SQL
+skemabase migrate up --dry-run
+
+# Roll back the last two migrations
+skemabase migrate down 2 --dry-run
+```
+
+Example output for 'migrate up --dry-run':
+```bash
+-- Migration: 20230504_add_email.js
+ALTER TABLE users ADD COLUMN email TEXT;
+
+Note: live execution not yet implemented.
+```
+
+Example output for 'migrate down --dry-run':
+```bash
+-- Migration: 20230504_add_email.js
+ALTER TABLE users DROP COLUMN email;
+
+Note: live execution not yet implemented.
+```
 
 ## Exit Codes
 - 0: Success (commands executed, or help/version shown)

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -32,3 +32,31 @@ The `examples/` directory contains sample schemas and the corresponding generate
 - `live/index.html`: Interactive web demo where you can edit a SkemaBase schema and see the IR and SQL in real time.
 
 You can use these examples as a starting point or reference for your own schemas.
+  
+## migrations
+This folder contains two schema snapshots under `examples/migration`:
+- `first.sb`: Initial schema
+- `second.sb`: Updated schema with an additional `email` attribute
+  
+Generate migrations using the CLI (run inside the `examples/migration` folder):
+```bash
+# Change to the migration examples directory
+cd examples/migration
+
+#! Initial migration from empty schema to first snapshot
+skemabase migrate create initial --to first.sb
+
+#! Diff migration from first snapshot to second snapshot
+skemabase migrate create add_email --from first.sb --to second.sb
+```
+  
+Preview SQL for all migrations (still inside `examples/migration`):
+```bash
+skemabase migrate up --dry-run
+```
+  
+Rollback migrations:
+```bash
+skemabase migrate down 2 --dry-run
+```
+

--- a/examples/migration/README.md
+++ b/examples/migration/README.md
@@ -1,0 +1,32 @@
+Migration Examples
+==================
+
+This folder contains two schema snapshots for demonstrating migrations with the SkemaBase CLI.
+
+Files:
+- first.sb: Initial schema definition.
+- second.sb: Updated schema with a new `email` attribute.
+
+Generate migrations using the CLI (run these inside this folder):
+```bash
+# Change to the examples/migration directory
+cd examples/migration
+
+# Initial migration from empty schema to first snapshot
+skemabase migrate create initial --to first.sb
+
+# Diff migration from first snapshot to second snapshot
+skemabase migrate create add_email --from first.sb --to second.sb
+```
+
+Preview SQL for all migrations:
+```bash
+skemabase migrate up --dry-run
+```
+See the generated SQL in `all_up.sql`.
+
+Rollback migrations:
+```bash
+skemabase migrate down 2 --dry-run
+```
+See the generated SQL in `all_down.sql`.

--- a/examples/migration/all_down.sql
+++ b/examples/migration/all_down.sql
@@ -1,0 +1,6 @@
+-- Migration: 20250502T161152_initial.js
+DROP TABLE user;
+DROP TABLE post;
+
+-- Migration: 20250502T161152_add_email.js
+ALTER TABLE user DROP COLUMN email;

--- a/examples/migration/all_up.sql
+++ b/examples/migration/all_up.sql
@@ -1,0 +1,14 @@
+-- Migration: 20250502T161152_add_email.js
+ALTER TABLE user ADD COLUMN email TEXT;
+
+-- Migration: 20250502T161152_initial.js
+CREATE TABLE user (
+  id SERIAL PRIMARY KEY,
+  id TEXT,
+  name TEXT
+);
+CREATE TABLE post (
+  id SERIAL PRIMARY KEY,
+  id TEXT,
+  title TEXT
+);

--- a/examples/migration/first.sb
+++ b/examples/migration/first.sb
@@ -1,0 +1,2 @@
+User has attributes: id serial, name text
+Post has attributes: id serial, title text

--- a/examples/migration/migrations/20250502T161152_add_email.js
+++ b/examples/migration/migrations/20250502T161152_add_email.js
@@ -1,0 +1,28 @@
+module.exports = {
+  "up": [
+    {
+      "name": "addColumn",
+      "args": [
+        "User",
+        {
+          "name": "email",
+          "type": null,
+          "unique": false,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "reversible": true
+    }
+  ],
+  "down": [
+    {
+      "name": "removeColumn",
+      "args": [
+        "User",
+        "email"
+      ],
+      "reversible": true
+    }
+  ]
+};

--- a/examples/migration/migrations/20250502T161152_initial.js
+++ b/examples/migration/migrations/20250502T161152_initial.js
@@ -1,0 +1,66 @@
+module.exports = {
+  "up": [
+    {
+      "name": "createTable",
+      "args": [
+        "User",
+        [
+          {
+            "name": "id",
+            "type": null,
+            "unique": false,
+            "nullable": true,
+            "default": null
+          },
+          {
+            "name": "name",
+            "type": null,
+            "unique": false,
+            "nullable": true,
+            "default": null
+          }
+        ]
+      ],
+      "reversible": true
+    },
+    {
+      "name": "createTable",
+      "args": [
+        "Post",
+        [
+          {
+            "name": "id",
+            "type": null,
+            "unique": false,
+            "nullable": true,
+            "default": null
+          },
+          {
+            "name": "title",
+            "type": null,
+            "unique": false,
+            "nullable": true,
+            "default": null
+          }
+        ]
+      ],
+      "reversible": true
+    }
+  ],
+  "down": [
+    {
+      "name": "dropTable",
+      "args": [
+        "User"
+      ],
+      "reversible": true
+    },
+    {
+      "name": "dropTable",
+      "args": [
+        "Post"
+      ],
+      "reversible": true
+    }
+  ]
+};

--- a/examples/migration/second.sb
+++ b/examples/migration/second.sb
@@ -1,0 +1,2 @@
+User has attributes: id serial, name text, email text
+Post has attributes: id serial, title text

--- a/skemabase-js/package-lock.json
+++ b/skemabase-js/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "skemabase-js",
       "version": "0.1.2",
+      "license": "MIT",
       "devDependencies": {
         "eslint": "^8.0.0",
         "jest": "^29.0.0",

--- a/skemabase-js/src/migration.js
+++ b/skemabase-js/src/migration.js
@@ -1,0 +1,145 @@
+// Migration diff engine and IR types
+
+const { generateSQL } = require('./sql');
+
+/**
+ * @typedef {Object} Op
+ * @property {string} name - operation name (e.g., 'createTable', 'dropTable')
+ * @property {any[]} args - arguments for the operation
+ * @property {boolean} reversible - whether the operation is reversible
+ */
+
+/**
+ * @typedef {Object} Migration
+ * @property {Op[]} up - operations to apply
+ * @property {Op[]} down - operations to rollback
+ */
+
+/**
+ * @typedef {Object} Op
+ * @property {string} name - operation name (e.g., 'createTable', 'dropTable')
+ * @property {any[]} args - arguments for the operation
+ * @property {boolean} reversible - whether the operation is reversible
+ */
+
+/**
+ * Compute the migration operations between two schema IR snapshots.
+ *
+ * @param {Array<{entity: string, attributes: any[], relationships: any[]}>} oldIR
+ * @param {Array<{entity: string, attributes: any[], relationships: any[]}>} newIR
+ * @returns {{ up: Op[], down: Op[] }} migration with up/down ops
+ */
+function diffSchemas(oldIR, newIR) {
+  const oldMap = new Map(oldIR.map(e => [e.entity, e]));
+  const newMap = new Map(newIR.map(e => [e.entity, e]));
+  const up = [];
+  const down = [];
+
+  // New entities → createTable in up, dropTable in down
+  for (const [entity, newDecl] of newMap) {
+    if (!oldMap.has(entity)) {
+      up.push({ name: 'createTable', args: [entity, newDecl.attributes], reversible: true });
+      down.push({ name: 'dropTable', args: [entity], reversible: true });
+    }
+  }
+
+  // Removed entities → dropTable in up, recreate in down
+  for (const [entity, oldDecl] of oldMap) {
+    if (!newMap.has(entity)) {
+      up.push({ name: 'dropTable', args: [entity], reversible: true });
+      down.push({ name: 'createTable', args: [entity, oldDecl.attributes], reversible: true });
+    }
+  }
+
+  // Attribute-level diffs for existing entities
+  for (const [entity, oldDecl] of oldMap) {
+    if (newMap.has(entity)) {
+      const newDecl = newMap.get(entity);
+      const oldAttrs = oldDecl.attributes || [];
+      const newAttrs = newDecl.attributes || [];
+      const oldNames = new Set(oldAttrs.map(a => a.name));
+      const newNames = new Set(newAttrs.map(a => a.name));
+      // Added attributes
+      for (const attr of newAttrs) {
+        if (!oldNames.has(attr.name)) {
+          up.push({ name: 'addColumn', args: [entity, attr], reversible: true });
+          down.push({ name: 'removeColumn', args: [entity, attr.name], reversible: true });
+        }
+      }
+      // Removed attributes
+      for (const attr of oldAttrs) {
+        if (!newNames.has(attr.name)) {
+          up.push({ name: 'removeColumn', args: [entity, attr.name], reversible: true });
+          down.push({ name: 'addColumn', args: [entity, attr], reversible: true });
+        }
+      }
+    }
+  }
+  return { up, down };
+}
+
+/**
+ * Convert TitleCase or camelCase name to snake_case
+ * @param {string} name
+ * @returns {string}
+ */
+function toSnakeCase(name) {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+/**
+ * Generate SQL statements for a migration.
+ * @param {Migration} migration
+ * @param {Object} [options]
+ * @param {string} [options.dialect='postgresql']
+ * @returns {{ upSQL: string, downSQL: string }}
+ */
+function generateMigrationSQL(migration, options = {}) {
+  const dialect = options.dialect || 'postgresql';
+  const upSQL = migration.up.map(op => sqlForOp(op, dialect)).join('\n');
+  const downSQL = migration.down.map(op => sqlForOp(op, dialect)).join('\n');
+  return { upSQL, downSQL };
+}
+
+/**
+ * Generate a SQL statement for a single migration operation.
+ * @param {Op} op
+ * @param {string} dialect
+ * @returns {string}
+ */
+function sqlForOp(op, dialect) {
+  const [entity, ...rest] = op.args;
+  switch (op.name) {
+    case 'createTable': {
+      const attrs = rest[0] || [];
+      return generateSQL([{ entity, attributes: attrs, relationships: [] }], { dialect });
+    }
+    case 'dropTable': {
+      const table = toSnakeCase(entity);
+      return `DROP TABLE ${table};`;
+    }
+    case 'addColumn': {
+      const [attr] = rest;
+      const table = toSnakeCase(entity);
+      const col = toSnakeCase(attr.name);
+      const type = attr.type ? attr.type.toUpperCase() : 'TEXT';
+      let def = `${col} ${type}`;
+      if (!attr.nullable) def += ' NOT NULL';
+      if (attr.unique) def += ' UNIQUE';
+      if (attr.default != null) def += ` DEFAULT ${attr.default}`;
+      return `ALTER TABLE ${table} ADD COLUMN ${def};`;
+    }
+    case 'removeColumn': {
+      const [col] = rest;
+      const table = toSnakeCase(entity);
+      return `ALTER TABLE ${table} DROP COLUMN ${col};`;
+    }
+    default:
+      throw new Error(`Unsupported migration op: ${op.name}`);
+  }
+}
+
+module.exports = { diffSchemas, generateMigrationSQL };

--- a/skemabase-js/tests/migration.test.js
+++ b/skemabase-js/tests/migration.test.js
@@ -1,0 +1,79 @@
+const { diffSchemas } = require('../src/migration');
+
+describe('diffSchemas', () => {
+  test('creates a createTable op for a new entity', () => {
+    const oldIR = [];
+    const newIR = [
+      { entity: 'users', attributes: [{ name: 'id', type: 'serial' }], relationships: [] }
+    ];
+    const { up, down } = diffSchemas(oldIR, newIR);
+    expect(up).toEqual([
+      { name: 'createTable', args: ['users', newIR[0].attributes], reversible: true }
+    ]);
+    expect(down).toEqual([
+      { name: 'dropTable', args: ['users'], reversible: true }
+    ]);
+  });
+
+  test('creates a dropTable op for a removed entity', () => {
+    const oldIR = [
+      { entity: 'users', attributes: [{ name: 'id', type: 'serial' }], relationships: [] }
+    ];
+    const newIR = [];
+    const { up, down } = diffSchemas(oldIR, newIR);
+    expect(up).toEqual([
+      { name: 'dropTable', args: ['users'], reversible: true }
+    ]);
+    expect(down).toEqual([
+      { name: 'createTable', args: ['users', oldIR[0].attributes], reversible: true }
+    ]);
+  });
+
+  test('no operations when schemas are identical', () => {
+    const ir = [
+      { entity: 'posts', attributes: [{ name: 'id', type: 'serial' }], relationships: [] }
+    ];
+    const result = diffSchemas(ir, ir);
+    expect(result).toEqual({ up: [], down: [] });
+  });
+  
+  test('adds a new attribute as addColumn op', () => {
+    const oldIR = [
+      { entity: 'users', attributes: [{ name: 'id', type: 'serial' }], relationships: [] }
+    ];
+    const newIR = [
+      { entity: 'users', attributes: [
+          { name: 'id', type: 'serial' },
+          { name: 'name', type: 'text' }
+        ], relationships: [] }
+    ];
+    const { up, down } = diffSchemas(oldIR, newIR);
+    expect(up).toEqual([
+      { name: 'addColumn', args: ['users', newIR[0].attributes[1]], reversible: true }
+    ]);
+    expect(down).toEqual([
+      { name: 'removeColumn', args: ['users', 'name'], reversible: true }
+    ]);
+  });
+
+  test('removes an attribute as removeColumn op', () => {
+    const oldIR = [
+      { entity: 'users', attributes: [
+          { name: 'id', type: 'serial' },
+          { name: 'age', type: 'integer' }
+        ], relationships: [] }
+    ];
+    const newIR = [
+      { entity: 'users', attributes: [
+          { name: 'id', type: 'serial' }
+        ], relationships: [] }
+    ];
+    const { up, down } = diffSchemas(oldIR, newIR);
+    expect(up).toEqual([
+      { name: 'removeColumn', args: ['users', 'age'], reversible: true }
+    ]);
+    expect(down).toEqual([
+      { name: 'addColumn', args: ['users', oldIR[0].attributes[1]], reversible: true }
+    ]);
+  });
+});

--- a/skemabase-js/tests/migrationSQL.test.js
+++ b/skemabase-js/tests/migrationSQL.test.js
@@ -1,0 +1,36 @@
+const { generateMigrationSQL } = require('../src/migration');
+
+describe('generateMigrationSQL', () => {
+  test('generates SQL for createTable and dropTable ops', () => {
+    const migration = {
+      up: [
+        { name: 'createTable', args: ['users', [{ name: 'name', type: 'text', nullable: true }]], reversible: true }
+      ],
+      down: [
+        { name: 'dropTable', args: ['users'], reversible: true }
+      ]
+    };
+    const { upSQL, downSQL } = generateMigrationSQL(migration, { dialect: 'postgresql' });
+    const expectedCreate =
+      'CREATE TABLE users (\n' +
+      '  id SERIAL PRIMARY KEY,\n' +
+      '  name TEXT\n' +
+      ');';
+    expect(upSQL).toBe(expectedCreate);
+    expect(downSQL).toBe('DROP TABLE users;');
+  });
+
+  test('generates SQL for addColumn and removeColumn ops', () => {
+    const migration = {
+      up: [
+        { name: 'addColumn', args: ['users', { name: 'age', type: 'integer', nullable: true }], reversible: true }
+      ],
+      down: [
+        { name: 'removeColumn', args: ['users', 'age'], reversible: true }
+      ]
+    };
+    const { upSQL, downSQL } = generateMigrationSQL(migration, { dialect: 'postgresql' });
+    expect(upSQL).toBe('ALTER TABLE users ADD COLUMN age INTEGER;');
+    expect(downSQL).toBe('ALTER TABLE users DROP COLUMN age;');
+  });
+});

--- a/todo.md
+++ b/todo.md
@@ -4,50 +4,15 @@ This document outlines the high-level roadmap for building SkemaBase, a tool tha
 lets you define database schemas in plain English and generate JSON IR, SQL DDL,
 ORM migrations, and diagrams.
 
----
-## Phase 1: Testing & CI/CD
-- [x] Set up Jest (JS)
-- [x] Add linting and formatting (ESLint, Prettier)
-- [x] Configure GitHub Actions for build, test, and publish workflows
-- [x] Monitor code coverage and enforce thresholds
+## Feature 1 - Migration Strategy
+Below is the detailed plan leveraging ActiveRecord-style reversible migrations:
 
-## Phase 2: Core Parsing & IR
-- [x] Formalize grammar (BNF) for schema statements
-- [x] Implement lexer/tokenizer
-- [x] Build parser to emit an AST from tokens
-- [x] Define JSON Intermediate Representation (IR) schema
-- [x] Serialize AST to JSON IR and back
-- [x] Write unit tests for parsing and IR generation
-
-## Phase 3: SQL Generation (MVP)
-- [x] Design mapping from IR to SQL DDL constructs
-- [x] Implement SQL generator for PostgreSQL
-- [x] Add support for SQLite
-- [x] Create SQL generator tests (round-trip IR → SQL → IR)
-- [x] Integrate `generate sql` command in CLI
-
-## Phase 4: Relationships & Constraints
-- [x] Extend IR to represent relationships (1:1, 1:N, N:M)
-- [x] Emit foreign keys, join tables, and constraints in SQL
-- [x] Support unique, not null, default value annotations
-- [x] Write integration tests for relational scenarios
-
-
-## Phase 5: Command-Line Interface
-- [x] Scaffold CLI package (Node.js)
-- [x] Implement `skemabase parse <file> --output <json>`
-- [x] Implement `skemabase generate sql <file> --dialect <dialect> --output <sql>`
-- [x] Add help (`--help`, `-h`) and version (`--version`, `-v`) flags
-- [x] Improve error handling (exit codes, messages)
-
-## Phase 6: Examples, Docs & Tutorials
-- [x] Populate `examples/` with schema files and generated artifacts
-- [x] Update README with quickstart and detailed usage
-- [x] Write comprehensive documentation (user guide, API reference)
-- [x] Create CONTRIBUTING.md and style guide
-
-## Phase 7: Releases & Maintenance
-- [x] Adopt semantic versioning (SemVer)
-- [x] Create CHANGELOG.md and release process
-- [ ] Plan feature roadmap and backlog grooming
-- [ ] Solicit community feedback and contributions
+- [x] Define Migration-IR types (`Migration`, `Op`) and JSDoc for each
+- [x] Scaffold `diffSchemas(oldIR, newIR)` to emit reversible ops (`createTable`, `dropTable`, etc.)
+- [x] Write Jest tests for `diffSchemas` covering entity add/remove scenarios
+- [x] Extend SQL generator to translate Migration-IR ops into up/down SQL DDL
+- [x] Integrate new CLI commands:
+  - `skemabase migrate init` (bootstraps migrations folder/config)
+  - `skemabase migrate create <name> [--from <old>.json --to <new>.json]`
+  - `skemabase migrate up|down [<n>]` with `--dry-run`, `--dialect`, `--url`
+- [x] Add documentation, examples, and update README/CLI docs


### PR DESCRIPTION
Introduce migration examples with initial and updated schemas, including SQL generation and rollback instructions. Update documentation to reflect new migration commands and options.