### PR TITLE
chore: add README for skemabase-js and bump versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skemabase-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Command-line interface for parsing plain-English database schemas and generating SQL or JSON IR.",
   "repository": {
     "type": "git",

--- a/skemabase-js/README.md
+++ b/skemabase-js/README.md
@@ -1,0 +1,42 @@
+ # skemabase-js
+
+ JavaScript SDK for parsing plain-English database schemas into a JSON intermediate representation (IR), generating SQL DDL, and creating Mermaid ER diagrams.
+
+ ## Installation
+
+ ```bash
+ npm install skemabase-js
+ ```
+
+ ## Usage
+
+ ```js
+ import { parse, generateSQL, generateMermaidDiagram } from 'skemabase-js';
+
+ const schema = `
+   User has attributes: username unique, email unique, created_at:timestamp default now()
+   User has many Post
+   Post has attributes: title not null, body, created_at:timestamp default now()
+ `;
+
+ const ir = parse(schema);
+ const sql = generateSQL(ir, { dialect: 'postgresql' });
+ console.log(sql);
+
+ const diagram = generateMermaidDiagram(ir);
+ console.log(diagram);
+ ```
+
+ ## API
+
+ - parse(text: string): Array<object>
+ - generateSQL(ir: Array<object>, options?: { dialect: 'postgresql' | 'sqlite' }): string
+ - generateMermaidDiagram(ir: Array<object>): string
+
+ ## Documentation
+
+ See the [SkemaBase CLI Reference](../docs/CLI.md) for command-line usage, and the [root README](../README.md) for full project documentation.
+
+ ## License
+
+ MIT

--- a/skemabase-js/package.json
+++ b/skemabase-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skemabase-js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JavaScript SDK for parsing plain-English database schemas into a JSON intermediate representation and generating SQL DDL.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR:
- Adds a dedicated README.md in skemabase-js with API, installation, and usage instructions for the JavaScript SDK.
- Bumps skemabase-js version to 0.1.3 and updates root skemabase-cli version to 0.1.2 so that npm packages have proper README docs.
